### PR TITLE
Add meta charset utf-8 in index view

### DIFF
--- a/views/index.ecr
+++ b/views/index.ecr
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8" />
     <title>Crystalshards</title>
     <link rel="stylesheet" href="/css/application.css">
   </head>


### PR DESCRIPTION
Because there's a repo with Chinese description and it looks like `ç…Žè›‹æ— èŠå›¾çˆ¬è™«` now
