### PR TITLE
Add ability to filter shards

### DIFF
--- a/app.cr
+++ b/app.cr
@@ -33,7 +33,8 @@ def fetch_sort(context)
 end
 
 def fetch_filter(context)
-  param = context.params["filter"]? || ""
+  filter = context.params["filter"]? || ""
+  filter.strip
 end
 
 get "/" do |context|

--- a/app.cr
+++ b/app.cr
@@ -19,15 +19,28 @@ def crystal_repos(sort)
   GithubRepos.from_json(response.body)
 end
 
+def filter(repos, filter)
+  filtered = repos.dup
+  filtered.items.select! { |item| item.name.includes? filter }
+  filtered.total_count = filtered.items.size
+  filtered
+end
+
 def fetch_sort(context)
   sort = context.params["sort"]? || "stars"
   sort = "stars" unless SORT_OPTIONS.includes?(sort)
   sort
 end
 
+def fetch_filter(context)
+  param = context.params["filter"]? || ""
+end
+
 get "/" do |context|
   sort = fetch_sort(context)
+  filter = fetch_filter(context)
   context.response.content_type = "text/html"
   repos = REPOS_CACHE.fetch(sort) { crystal_repos(sort) }
-  Views::Index.new repos, sort
+  repos = filter(repos, filter) unless filter.empty?
+  Views::Index.new repos, sort, filter
 end

--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -1,0 +1,5 @@
+window.onload = function() {
+  document.getElementById('sort').onchange = function() {
+    this.form.submit();
+  }
+}

--- a/assets/stylesheets/_index.sass
+++ b/assets/stylesheets/_index.sass
@@ -37,7 +37,7 @@ a
   color: $text-color-dark
   padding: 50px
 
-  .sorting
+  .nav
     padding-bottom: 50px
 
   .repo

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,12 @@ var gulp = require('gulp'),
     sass = require('gulp-sass'),
     neat = require('node-neat').includePaths;
 
+gulp.task('js', function(){
+  return gulp
+    .src('assets/js/*.js')
+    .pipe(gulp.dest('public/js'));
+})
+
 gulp.task('sass', function () {
   return gulp
     .src('assets/stylesheets/**/*.sass')
@@ -10,5 +16,6 @@ gulp.task('sass', function () {
 });
 
 gulp.task('default', function() {
+  gulp.start('js');
   gulp.start('sass');
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ gulp.task('js', function(){
   return gulp
     .src('assets/js/*.js')
     .pipe(gulp.dest('public/js'));
-})
+});
 
 gulp.task('sass', function () {
   return gulp

--- a/models/github_repos.cr
+++ b/models/github_repos.cr
@@ -6,4 +6,8 @@ class GithubRepos
     total_count: { type: Int32 },
     items: { type: Array(GithubRepo) }
   })
+
+  def dup
+    GithubRepos.from_json self.to_json
+  end
 end

--- a/public/css/application.css
+++ b/public/css/application.css
@@ -47,7 +47,7 @@ a {
   background-color: #E6D3A3;
   color: #5B5B5B;
   padding: 50px; }
-  .repos .sorting {
+  .repos .nav {
     padding-bottom: 50px; }
   .repos .repo {
     list-style: none;

--- a/public/js/application.js
+++ b/public/js/application.js
@@ -1,0 +1,5 @@
+window.onload = function() {
+  document.getElementById('sort').onchange = function() {
+    this.form.submit();
+  }
+}

--- a/views/index.cr
+++ b/views/index.cr
@@ -3,7 +3,7 @@ require "ecr/macros"
 class Views::Index
   getter :crystal_repos, :repos_count, :sort, :filter
 
-  def initialize(repos_data, sort, filter = nil)
+  def initialize(repos_data, sort, filter)
     @repos_count = repos_data.total_count
     @crystal_repos = repos_data.items
     @sort = sort

--- a/views/index.cr
+++ b/views/index.cr
@@ -1,12 +1,13 @@
 require "ecr/macros"
 
 class Views::Index
-  getter :crystal_repos, :repos_count, :sort
+  getter :crystal_repos, :repos_count, :sort, :filter
 
-  def initialize(repos_data, sort)
+  def initialize(repos_data, sort, filter = nil)
     @repos_count = repos_data.total_count
     @crystal_repos = repos_data.items
     @sort = sort
+    @filter = filter
     @now = Time.utc_now
   end
 

--- a/views/index.ecr
+++ b/views/index.ecr
@@ -12,7 +12,13 @@
       <div class="container">
         <h1 class="title">Crystalshards</h1>
 
-        <p class="more-info">There are a total of <span class="repo-count"><%= repos_count %></span> shards</p>
+        <p class="more-info">
+          <% if filter.empty? %>
+            There are a total of <span class="repo-count"><%= repos_count %></span> shards
+          <% else %>
+            There are a total of <span class="repo-count"><%= repos_count %></span> shards that match your query
+          <% end %>
+        </p>
       </div>
     </section>
 

--- a/views/index.ecr
+++ b/views/index.ecr
@@ -4,9 +4,10 @@
     <meta charset="utf-8" />
     <title>Crystalshards</title>
     <link rel="stylesheet" href="/css/application.css">
+    <script type="text/javascript" src="/js/application.js" ></script>
   </head>
 
-  <body onload="document.forms['search'].elements['search'].select();">
+  <body>
     <section class="main-info">
       <div class="container">
         <h1 class="title">Crystalshards</h1>
@@ -20,16 +21,16 @@
         <div class="nav">
           <form id="search" method="get" action="/">
             Sort by:
-              <select name="sort" onchange="this.form.submit()">
+              <select id="sort" name="sort">
                 <% SORT_OPTIONS.each_with_index do |target_sort, index| %>
-                <option <%= "selected" if sort == target_sort %>>
-                   <%= target_sort %>
-                </option>
+                  <option <%= "selected" if sort == target_sort %>>
+                     <%= target_sort %>
+                  </option>
                 <% end %>
               </select>
 
             Filter:
-              <input type="search" id="search" name="filter" value="<%= filter %>" maxlength="20"/>
+              <input type="search" id="filter" name="filter" maxlength="20" autofocus/>
           </form>
         </div>
 

--- a/views/index.ecr
+++ b/views/index.ecr
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/css/application.css">
   </head>
 
-  <body>
+  <body onload="document.forms['search'].elements['search'].select();">
     <section class="main-info">
       <div class="container">
         <h1 class="title">Crystalshards</h1>
@@ -17,16 +17,20 @@
 
     <section class="repos">
       <div class="container">
-        <div class="sorting">
-          Sort by:
-            <% SORT_OPTIONS.each_with_index do |target_sort, index| %>
-              <% if index > 0 %> | <% end %>
-              <% if sort == target_sort %>
-                <%= target_sort %>
-              <% else %>
-                <a href="?sort=<%= target_sort %>"><%= target_sort %></a>
-              <% end %>
-            <% end %>
+        <div class="nav">
+          <form id="search" method="get" action="/">
+            Sort by:
+              <select name="sort" onchange="this.form.submit()">
+                <% SORT_OPTIONS.each_with_index do |target_sort, index| %>
+                <option <%= "selected" if sort == target_sort %>>
+                   <%= target_sort %>
+                </option>
+                <% end %>
+              </select>
+
+            Filter:
+              <input type="search" id="search" name="filter" value="<%= filter %>" maxlength="20"/>
+          </form>
         </div>
 
         <ul>


### PR DESCRIPTION
In my opinion it would be useful to filter or search shards with crystalshards. Especially with a large number of available projects. 

This PR adds a possibility to filter crystal shards in place (using cache) by name:

![crystal_shards_pr](https://cloud.githubusercontent.com/assets/3624712/9039532/c7072bc2-3a04-11e5-9a46-5212fd73b71d.png)

Now "sort" parameter is represented by "select" html tag to be automatically delivered with "filter" parameter during form submitting: `crystalshards_url/?sort=stars&filter=crystalshards`
