### PR TITLE
Add fallback fonts

### DIFF
--- a/assets/stylesheets/_index.sass
+++ b/assets/stylesheets/_index.sass
@@ -6,7 +6,7 @@
   padding: 0
 
 body
-  font-family: "Helvetica Neue"
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif
 
 a
   color: $color-link


### PR DESCRIPTION
With Helvetica Neue as only font set for the body, people without the font would just see the site with Times New Roman (or their default browser font). This fix adds Helvetica, which is installed on most systems, and several other standard fonts as fallback.

Example _(only `"Helvetica Neue"` as font)_:
![](https://jii.moe/NJ77oswvl.png)

Example _(with fallback fonts)_:
![](https://jii.moe/Ek47jiDDx.png)
