### PR TITLE
security: html escape all strings

### DIFF
--- a/models/github_repo.cr
+++ b/models/github_repo.cr
@@ -1,4 +1,5 @@
 require "json"
+require "html"
 
 class GithubRepo
   JSON.mapping({
@@ -11,9 +12,25 @@ class GithubRepo
     forks: { type: Int32 },
   })
 
+  def name
+    HTML.escape @name
+  end
+
+  def html_url
+    HTML.escape @html_url
+  end
+
+  def description
+    @description ? HTML.escape @description.not_nil! : nil
+  end
+
   struct Owner
     JSON.mapping({
       login: String,
     })
+
+    def login
+      HTML.escape @login
+    end
   end
 end


### PR DESCRIPTION
Hello,

I noticed that CrystalShards did not escape any HTML entities before rendering them to the document.

This leads to an XSS exploit as demonstrated with the following repository: [repo link](https://github.com/jessedoyle/crystalshards_xss). 

You can see console output from the injected script when visiting the following page: [link](http://crystalshards.herokuapp.com/?sort=updated&filter=).

I have no malicious intent, this PR should fix the issue by properly escaping the strings returned from the GitHub API. 
