### PR TITLE
Render more than 100 repos

### DIFF
--- a/app.cr
+++ b/app.cr
@@ -45,15 +45,12 @@ end
 
 def sort(repos, sort)
   sorted = repos.dup
-  if sort == "stars"
+  case sort
+  when "stars"
     sorted.items.sort! { |a, b| b.stargazers_count <=> a.stargazers_count  }
-  end
-
-  if sort == "updated"
+  when "updated"
     sorted.items.sort! { |a, b| b.updated_at <=> a.updated_at  }
-  end
-
-  if sort == "forks"
+  when "forks"
     sorted.items.sort! { |a, b| b.forks_count <=> a.forks_count  }
   end
   sorted

--- a/models/github_repo.cr
+++ b/models/github_repo.cr
@@ -7,7 +7,10 @@ class GithubRepo
     html_url: { type: String },
     description: { type: String, nilable: true },
     watchers_count: { type: Int32 },
+    stargazers_count: { type: Int32 },
+    forks_count: {type: Int32 },
     owner: Owner,
+    updated_at: { type: Time, converter: Time::Format.new("%FT%TZ") },
     pushed_at: { type: Time, converter: Time::Format.new("%FT%TZ") },
     forks: { type: Int32 },
   })


### PR DESCRIPTION
Because of the multiple api request the first request before the caching takes some time. :(
I reimplemented the sort feature as a local sorting, because it breaks when merging multiple pages.

We should also think about indexing repos persistently in our own data store. Github is [only returning up to 1000 repositories](https://developer.github.com/v3/search/) through their search.

Fixes #6 
